### PR TITLE
File selector and input tweaks

### DIFF
--- a/src/components/LogoSelector.tsx
+++ b/src/components/LogoSelector.tsx
@@ -1,7 +1,5 @@
 import { useAppStateStore } from "@/store";
-import { HoverCard, HoverCardTrigger, HoverCardContent } from "./ui/hover-card";
 import { Input } from "./ui/input";
-import { Label } from "./ui/label";
 
 export function LogoSelector() {
   const { state, setState } = useAppStateStore();
@@ -13,16 +11,23 @@ export function LogoSelector() {
       setState("logo", reader.result as string);
     };
 
-    if (file) {
-      reader.readAsDataURL(file);
-    } else {
-      setState("logo", "");
+    if (!file) {
+      // We don't want to unset the current file when no file is selected
+      return;
     }
+
+    reader.readAsDataURL(file);
   };
 
   return (
     <div className="grid gap-2">
-      <Input type="file" id="logo" onChange={handleImageUpload} />
+      <Input
+        type="file"
+        id="logo"
+        accept="image/*"
+        className="cursor-pointer"
+        onChange={handleImageUpload}
+      />
       {state.logo && (
         <img src={state.logo} alt="logo" className="w-20 h-20 object-contain" />
       )}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
@@ -11,15 +11,15 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:cursor-pointer placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ",
           className
         )}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = "Input";
 
-export { Input }
+export { Input };


### PR DESCRIPTION
- Center file input
- Show pointer over the entire file input
- Restrict file types to images
- Don't clear selected file if no file is selected
- Move input focus ring inside the input so that it doesn't overflow the container (see pic)

**Before inset**
<img width="286" alt="Screenshot 2023-08-01 at 6 36 32 pm" src="https://github.com/wseagar/invoice-kitchen/assets/13460254/ea7c1496-def7-4e58-a582-bdf1aa6c0da3">

**After inset**
<img width="286" alt="Screenshot 2023-08-01 at 6 36 45 pm" src="https://github.com/wseagar/invoice-kitchen/assets/13460254/f57a0f57-96e2-4435-95f7-de8113cbff7a">

---

PR Train (Each is branched off the one above):

| Title | PR |
-|-
| 👉  File selector input tweaks | https://github.com/wseagar/invoice-kitchen/pull/2 |
| Add Prettier | https://github.com/wseagar/invoice-kitchen/pull/3 |
| Add logo overlay | https://github.com/wseagar/invoice-kitchen/pull/4 |
