### PR TITLE
Add logo overlay

### DIFF
--- a/src/components/LogoSelector.tsx
+++ b/src/components/LogoSelector.tsx
@@ -1,27 +1,40 @@
+import React from 'react';
 import { useAppStateStore } from '@/store';
 import { Input } from './ui/input';
 
 export function LogoSelector() {
   const { state, setState } = useAppStateStore();
-  const handleImageUpload = (event: any) => {
-    const file = event.target.files[0];
-    const reader = new FileReader();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const handleImageUpload = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
 
-    reader.onloadend = () => {
-      setState('logo', reader.result as string);
-    };
+      if (!file) {
+        // We don't want to unset the current file when no file is selected
+        return;
+      }
 
-    if (!file) {
-      // We don't want to unset the current file when no file is selected
-      return;
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setState('logo', reader.result as string);
+      };
+
+      reader.readAsDataURL(file);
+    },
+    [setState],
+  );
+
+  const clearImage = React.useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
     }
-
-    reader.readAsDataURL(file);
-  };
+    setState('logo', '');
+  }, [setState]);
 
   return (
     <div className="grid gap-2">
       <Input
+        ref={inputRef}
         type="file"
         id="logo"
         accept="image/*"
@@ -29,7 +42,21 @@ export function LogoSelector() {
         onChange={handleImageUpload}
       />
       {state.logo && (
-        <img src={state.logo} alt="logo" className="w-20 h-20 object-contain" />
+        <div className="relative w-full h-full p-2 rounded-md overflow-hidden">
+          <img
+            src={state.logo}
+            alt="logo"
+            className="w-full h-full object-contain"
+          />
+          <div
+            className="absolute left-0 top-0 w-full h-full opacity-0 hover:opacity-100 bg-gray-700 bg-opacity-70 cursor-pointer"
+            onClick={clearImage}
+          >
+            <div className="flex justify-center items-center h-full">
+              <div className="text-white text-lg select-none">Remove</div>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ export function Sidebar() {
     <div
       className={cx(
         // todo: transition
-        'h-full min-w-[300px] bg-white text-black overflow-auto',
+        'h-full min-w-[300px] w-[300px] bg-white text-black overflow-auto',
         !state.sidebarOpen ? 'hidden' : '',
       )}
     >


### PR DESCRIPTION
Adds an overlay over the logo that allows for easy removal. This PR also extends the image to take the full width of the sidebar.

Default and hovered states:

<img width="286" alt="Screenshot 2023-08-01 at 8 03 05 pm" src="https://github.com/wseagar/invoice-kitchen/assets/13460254/a95a3084-bb2f-42c4-95c9-054443a7323f">

<img width="286" alt="Screenshot 2023-08-01 at 8 03 02 pm" src="https://github.com/wseagar/invoice-kitchen/assets/13460254/e07d2fbc-e4ab-42a8-9129-9b50d7fbeada">

---

PR Train (Each is branched off the one above):

| Title | PR |
-|-
| File selector input tweaks | https://github.com/wseagar/invoice-kitchen/pull/2 |
| Add Prettier | https://github.com/wseagar/invoice-kitchen/pull/3 |
| 👉 Add logo overlay | https://github.com/wseagar/invoice-kitchen/pull/4 |
